### PR TITLE
BanService Edits + Cmdr Opts

### DIFF
--- a/src/server/Commands/ban.lua
+++ b/src/server/Commands/ban.lua
@@ -1,13 +1,13 @@
 return {
 	Name = "ban",
 	Aliases = {},
-	Description = "Bans a player from the game.",
+	Description = "Permanently bans a player from the game.",
 	Group = "Admin",
 	Args = {
 		{
 			Type = "playerId",
 			Name = "player",
-			Description = "The full player name to ban.",
+			Description = "The player to ban.",
 		},
 		{
 			Type = "string",

--- a/src/server/Commands/banServer.lua
+++ b/src/server/Commands/banServer.lua
@@ -6,25 +6,25 @@ local BanService = require(ServerStorage.Storage.Modules.BanService)
 local Admins = require(ServerStorage.Storage.Modules.Admins)
 
 return function(Context, Victim, Reason)
-	if not Reason then
-		return "Reason required."
-	end
 	local Executor = Context.Executor
 	local isVictimBanned = BanService:GetBanInfo(Victim)
 
 	if Victim == Executor.UserId then
-		return "You can't perform this action on yourself."
+		return "Error: You can't perform this action on yourself."
 	end
+	
 	for _, b in next, Admins do
 		if b == Victim then
-			return "You can't perform this action on another moderator."
+			return "Error: You can't perform this action on another moderator."
 		end
 	end
+	
 	if isVictimBanned then
-		return Players:GetNameFromUserIdAsync(Victim) .. " is already banned."
+		return "Error: " .. Players:GetNameFromUserIdAsync(Victim) .. " is already banned."
 	end
+	
 	if #Reason > 85 then
-		return "Reason too long."
+		return "Error: Reason too long. Cap: 85chars"
 	end
 
 	local Format = ("\nBanned from all servers!\nModerator: %s\nReason: %s"):format(
@@ -34,10 +34,10 @@ return function(Context, Victim, Reason)
 
 	local err = BanService:Add(Victim, Executor.UserId, Reason)
 	if err then
-		return tostring(err)
+		return "Error: " .. tostring(err)
 	end
 
-	for _, b in next, Players:GetPlayers() do
+	for _, b in ipairs(Players:GetPlayers()) do
 		if b.UserId == Victim then
 			b:Kick(Format)
 		end

--- a/src/server/Commands/baninfo.lua
+++ b/src/server/Commands/baninfo.lua
@@ -7,7 +7,7 @@ return {
 		{
 			Type = "playerId",
 			Name = "player",
-			Description = "The full player name to check.",
+			Description = "The player to get information on.",
 		},
 	},
 }

--- a/src/server/Commands/baninfoServer.lua
+++ b/src/server/Commands/baninfoServer.lua
@@ -8,10 +8,11 @@ return function(Context, Player)
 	local PlayerBanned, BanReason, ExecutorId, System = BanService:GetBanInfo(Player)
 
 	if Player == Executor.UserId then
-		return "You can't perform this action on yourself."
+		return "Error: You can't perform this action on yourself."
 	end
+	
 	if not PlayerBanned then
-		return Players:GetNameFromUserIdAsync(Player) .. " is not banned."
+		return "Error: " .. Players:GetNameFromUserIdAsync(Player) .. " is not banned."
 	end
 
 	return ('%s was banned by %s for: "%s"'):format(

--- a/src/server/Commands/help.lua
+++ b/src/server/Commands/help.lua
@@ -1,62 +1,39 @@
-local ARGUMENT_SHORTHANDS = [[
-Argument Shorthands
--------------------            
-.   Me/Self
-*   All/Everyone 
-**  Others 
-?   Random
-?N  List of N random values            
-]]
 return {
-	Name = "help",
-	Description = "Displays a list of all commands, or inspects one command.",
-	Aliases = { "cmds" },
-	Group = "Help",
+	Name = "help";
+	Description = "Displays a list of all commands, or inspects one command.";
+	Group = "Help";
 	Args = {
 		{
-			Type = "command",
-			Name = "Command",
-			Description = "The command to view information on",
-			Optional = true,
+			Type = "command";
+			Name = "Command";
+			Description = "The command to view information on";
+			Optional = true;
 		},
-	},
-	ClientRun = function(context, commandName)
+	};
+
+	ClientRun = function (context, commandName)
 		if commandName then
 			local command = context.Cmdr.Registry:GetCommand(commandName)
 			context:Reply(("Command: %s"):format(command.Name), Color3.fromRGB(230, 126, 34))
 			if command.Aliases and #command.Aliases > 0 then
-				context:Reply(
-					("Aliases: %s"):format(table.concat(command.Aliases, ", ")),
-					Color3.fromRGB(230, 230, 230)
-				)
+				context:Reply(("Aliases: %s"):format(table.concat(command.Aliases, ", ")), Color3.fromRGB(230, 230, 230))
 			end
 			context:Reply(command.Description, Color3.fromRGB(230, 230, 230))
 			for i, arg in ipairs(command.Args) do
-				context:Reply(
-					("#%d %s%s: %s - %s"):format(
-						i,
-						arg.Name,
-						arg.Optional == true and "?" or "",
-						arg.Type,
-						arg.Description
-					)
-				)
+				context:Reply(("#%d %s%s: %s - %s"):format(
+					i,
+					arg.Name,
+					arg.Optional == true and "?" or "",
+					arg.Type, arg.Description
+				))
 			end
 		else
-			context:Reply(ARGUMENT_SHORTHANDS)
 			local commands = context.Cmdr.Registry:GetCommands()
-			table.sort(commands, function(a, b)
-				return a.Group < b.Group
-			end)
-			local lastGroup
-			for _, command in ipairs(commands) do
-				if lastGroup ~= command.Group then
-					context:Reply(("\n%s\n-------------------"):format(command.Group))
-					lastGroup = command.Group
-				end
-				context:Reply(("%s - %s"):format(command.Name, command.Description))
+
+			for _, cmd in pairs(commands) do
+				context:Reply(("%s - %s"):format(cmd.Name, cmd.Description))
 			end
 		end
 		return ""
-	end,
+	end;
 }

--- a/src/server/Commands/kick.lua
+++ b/src/server/Commands/kick.lua
@@ -1,6 +1,6 @@
 return {
 	Name = "kick",
-	Aliases = {},
+	Aliases = {"boot"},
 	Description = "Kicks a player from the server.",
 	Group = "Admin",
 	Args = {

--- a/src/storage/Modules/BanService.lua
+++ b/src/storage/Modules/BanService.lua
@@ -90,7 +90,6 @@ function banService:Add(Id: number, Executor: number, Reason: string | number): 
 			end)
 			:await()
 		if Err then
-			print(typeof(Err))
 			return "Error: " .. tostring(Err)
 		end
 	end
@@ -105,9 +104,6 @@ function banService:Remove(Id: number): (string?)
 			end)
 			:await()
 		if Err then
-			for a, b in next, Err do
-				print(a, b)
-			end
 			return "Error: " .. tostring(Err)
 		end
 	end

--- a/src/storage/Modules/BanService.lua
+++ b/src/storage/Modules/BanService.lua
@@ -22,7 +22,17 @@ local Settings = {
 	storeKey = "playerBans//",
 }
 
-local retry = {}
+local function makeLibraryMeta(Name: string): ({ [string]: (...any) -> (nil) })
+	return {
+		__index = function(_, indx: string)
+			error(
+				("Ban Service::inBuiltLibraryError: %s is not a function of %s.\n\n%s"):format(indx, Name, debug.traceback())
+			)
+		end,
+	}
+end
+
+local retry = setmetatable({}, makeLibraryMeta("retry"))
 
 --
 


### PR DESCRIPTION
- Removes prints and left debugging information from prior tests.
- Revert Cmdr's new & organized "help" command to a previous version.